### PR TITLE
Adding user site to path

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -37,6 +37,10 @@ from bpy.props import (
     StringProperty,
     FloatProperty,
 )
+import site
+app_path = site.USER_SITE
+if app_path not in sys.path:
+    sys.path.append(app_path)
 
 pybin = sys.executable  # bpy.app.binary_path_python # Use for 2.83
 try:


### PR DESCRIPTION
Dear friend,
    Thanks your good work.
    If blender installed by snap mode, we should add "user site path", otherwise the addon could not find module scenedetect.
    For our /snap/blender/current/2.93/, user site package is under "~/.local/lib/python3.9/site-packages/".
Best regards,

